### PR TITLE
問題一覧ページを実装

### DIFF
--- a/app/forms/question_form.rb
+++ b/app/forms/question_form.rb
@@ -5,9 +5,9 @@ class QuestionForm
   attr_accessor :title, :user_id
   attr_accessor :option1_content, :option2_content
 
-  validates :title, presence: true, length: { maximum: 50 }
-  validates :option1_content, presence: true, length: { maximum: 50 }
-  validates :option2_content, presence: true, length: { maximum: 50 }
+  validates :title, presence: true, length: { maximum: 29 }
+  validates :option1_content, presence: true, length: { maximum: 29 }
+  validates :option2_content, presence: true, length: { maximum: 29 }
   validates :user_id, presence: true
 
   def initialize(question: nil, params: {})

--- a/app/javascript/controllers/textarea_controller.js
+++ b/app/javascript/controllers/textarea_controller.js
@@ -2,7 +2,7 @@ import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
   static targets = ["input", "label", "counter", "currentLength"]
-  static values = { maxLength: { type: Number, default: 50 } }
+  static values = { maxLength: { type: Number, default: 29 } }
 
   connect() {
     this.updateCounter()

--- a/app/models/option.rb
+++ b/app/models/option.rb
@@ -1,6 +1,6 @@
 class Option < ApplicationRecord
     belongs_to :question
 
-    validates :content, presence: true, length: { maximum: 50 }
+    validates :content, presence: true, length: { maximum: 29 }
     validates :question_id, presence: true
 end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -2,6 +2,6 @@ class Question < ApplicationRecord
   belongs_to :user
   has_many :options, dependent: :destroy
 
-  validates :title, presence: true, length: { maximum: 50 }
+  validates :title, presence: true, length: { maximum: 29 }
   validates :user_id, presence: true
 end

--- a/app/views/questions/_form.html.erb
+++ b/app/views/questions/_form.html.erb
@@ -14,7 +14,7 @@
             class: "absolute left-3 top-3 text-black transition-all duration-200 peer-focus:top-1 peer-focus:left-3 peer-focus:text-xs peer-focus:text-orange peer-placeholder-shown:top-3 peer-placeholder-shown:text-base peer-not-placeholder-shown:top-1 peer-not-placeholder-shown:left-3 peer-not-placeholder-shown:text-xs peer-not-placeholder-shown:text-orange" %>
 
         <div data-textarea-target="counter" class="absolute bottom-1 right-2 text-xs text-black">
-          <span data-textarea-target="currentLength">0</span>/<%= 50 %>
+          <span data-textarea-target="currentLength">0</span>/<%= 29 %>
         </div>
 
         <% @question_form.errors.full_messages_for(:title).each do |message| %>
@@ -33,7 +33,7 @@
             data: { textarea_target: "label" },
             class: "absolute left-3 top-3 text-black transition-all duration-200 peer-focus:top-1 peer-focus:left-3 peer-focus:text-xs peer-focus:text-orange peer-placeholder-shown:top-3 peer-placeholder-shown:text-base peer-not-placeholder-shown:top-1 peer-not-placeholder-shown:left-3 peer-not-placeholder-shown:text-xs peer-not-placeholder-shown:text-orange" %>
         <div data-textarea-target="counter" class="absolute bottom-1 right-2 text-xs text-black">
-          <span data-textarea-target="currentLength">0</span>/<%= 50 %>
+          <span data-textarea-target="currentLength">0</span>/<%= 29 %>
         </div>
         <% @question_form.errors.full_messages_for(:option1_content).each do |message| %>
           <p class="text-red-500 text-xs italic mt-1"><%= message %></p>
@@ -49,7 +49,7 @@
             data: { textarea_target: "label" },
             class: "absolute left-3 top-3 text-black transition-all duration-200 peer-focus:top-1 peer-focus:left-3 peer-focus:text-xs peer-focus:text-orange peer-placeholder-shown:top-3 peer-placeholder-shown:text-base peer-not-placeholder-shown:top-1 peer-not-placeholder-shown:left-3 peer-not-placeholder-shown:text-xs peer-not-placeholder-shown:text-orange" %>
         <div data-textarea-target="counter" class="absolute bottom-1 right-2 text-xs text-black">
-          <span data-textarea-target="currentLength">0</span>/<%= 50 %>
+          <span data-textarea-target="currentLength">0</span>/<%= 29 %>
         </div>
         <% @question_form.errors.full_messages_for(:option2_content).each do |message| %>
           <p class="text-red-500 text-xs italic mt-1"><%= message %></p>

--- a/app/views/questions/_question.html.erb
+++ b/app/views/questions/_question.html.erb
@@ -1,9 +1,12 @@
 
-  <div class="card-content">
-    <h2 class="question-title"><%= question.title %></h2>
-  </div>
-    <div class="user-icon">
-      <img src="<%= question.user.google_image_url %>" alt="<%= question.user.name %>" class="w-10 rounded-full">
+  <div class="bg-blue w-70 h-50 p-6 mt-6 rounded-lg shadow-md space-y-4">
+    <h2 class="text-xl font-bold"><%= question.title %></h2>
+    <div class="flex items-center space-x-2">
+      <img src="<%= question.user.google_image_url %>" alt="<%= question.user.name %>" class="w-8 h-8 rounded-full">
+      <span class="font-medium"><%= question.user.name %>(作成者)</span>
     </div>
-    <span class="user-name"><%= question.user.name %></span>
-</div>
+    <div class="flex items-center space-x-2">
+      <i class="fa-regular fa-face-laugh-beam"></i>
+      <span>投票数</span>
+    </div>
+  </div>

--- a/app/views/questions/index.html.erb
+++ b/app/views/questions/index.html.erb
@@ -1,2 +1,5 @@
-<h1>Questions#index</h1>
-<p>Find me in app/views/questions/index.html.erb</p>
+<div class="m-10 h-auto bg-yellow-200">
+  <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6 gap-4">
+    <%= render @questions %>
+  </div>
+</div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -8,7 +8,7 @@
     <div class="flex items-center space-x-8">
       <div class="flex space-x-8">
         <%= link_to "お題を作成する", new_question_path, class: "text-black hover:underline hover:text-orange hover:decoration-orange" %>
-        <%= link_to "究極の二択問題一覧", "#", class: "text-black hover:underline hover:text-orange hover:decoration-orange" %>
+        <%= link_to "究極の二択問題一覧", questions_path, class: "text-black hover:underline hover:text-orange hover:decoration-orange" %>
       </div>
 
 

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -7,14 +7,14 @@
     <% end %>
 
     <h2 class="mt-15 text-2xl">あなたの投稿したお題</h2>
-    <% if @user.questions.any? %>
-        <div class="user-questions-list">
-        <% @user.questions.each do |question| %>
-            <%= render "questions/question", question: question %>
+        <% if @user.questions.any? %>
+            <div class="user-questions-list">
+            <% @user.questions.each do |question| %>
+                <%= render "questions/question", question: question %>
+            <% end %>
+            </div>
+        <% else %>
+            <p>まだお題を投稿していません。</p>
+            <%= link_to "新しいお題を投稿する", new_question_path, class: "button" %>
         <% end %>
-        </div>
-    <% else %>
-        <p>まだお題を投稿していません。</p>
-        <%= link_to "新しいお題を投稿する", new_question_path, class: "button" %>
-    <% end %>
 </div>

--- a/spec/forms/question_form_spec.rb
+++ b/spec/forms/question_form_spec.rb
@@ -42,8 +42,8 @@ RSpec.describe QuestionForm, type: :form do
         expect(form.errors[:title]).to be_present
       end
 
-      it 'titleが50文字を超える場合、無効であること' do
-        long_title = 'a' * 51
+      it 'title29文字を超える場合、無効であること' do
+        long_title = 'a' * 30
         form = QuestionForm.new(params: valid_attributes.merge(title: long_title)) # valid_attributesを正しい引数に修正
         expect(form).to be_invalid
         expect(form.errors[:title]).to be_present
@@ -63,8 +63,8 @@ RSpec.describe QuestionForm, type: :form do
         expect(form.errors[:option1_content]).to be_present
       end
 
-      it 'option1_contentが50文字を超える場合、無効であること' do
-        long_content = 'a' * 51
+      it 'option1_contentが29文字を超える場合、無効であること' do
+        long_content = 'a' * 30
         form = QuestionForm.new(params: valid_attributes.merge(option1_content: long_content))
         expect(form).to be_invalid
         expect(form.errors[:option1_content]).to be_present
@@ -83,8 +83,8 @@ RSpec.describe QuestionForm, type: :form do
         expect(form.errors[:option2_content]).to be_present
       end
 
-      it 'option2_contentが50文字を超える場合、無効であること' do
-        long_content = 'a' * 51
+      it 'option2_contentが29文字を超える場合、無効であること' do
+        long_content = 'a' * 30
         form = QuestionForm.new(params: valid_attributes.merge(option2_content: long_content))
         expect(form).to be_invalid
         expect(form.errors[:option2_content]).to be_present


### PR DESCRIPTION
問題一覧ページを実装しました。
カード形式で表示しており、
１つのカードには以下の内容が含まれています。
・タイトル
・ユーザーアイコン
・ユーザー名
・投票数（仮）

また1つのカードの幅に合わせて、文字数・選択肢を50文字→29文字に変更。
それに伴いテストコードもも50文字→29文字に変更しました。