### PR TITLE
お題編集機能を制限

### DIFF
--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -27,10 +27,19 @@ class QuestionsController < ApplicationController
   end
 
   def edit
+    unless @question.editable?
+      redirect_to @question, alert: "回答や意見がある質問は編集できません"
+      return
+    end
+
     @question_form = QuestionForm.new(question: @question)
   end
 
   def update
+    unless @question.editable?
+      redirect_to @question, alert: "回答や意見がある質問は編集できません"
+      return
+    end
     @question_form = QuestionForm.new(question: @question, attributes: question_form_params.merge(user_id: current_user.id))
       if @question_form.save
         flash.now[:notice] = "お題が更新されました"

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -11,7 +11,7 @@ class Question < ApplicationRecord
   def total_votes
     votes.count
   end
-  
+
   def editable?
     votes.empty? && opinions.empty?
   end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -11,4 +11,12 @@ class Question < ApplicationRecord
   def total_votes
     votes.count
   end
+  
+  def editable?
+    votes.empty? && opinions.empty?
+  end
+
+  def has_responses?
+    votes.exists? || opinions.exists?
+  end
 end

--- a/app/views/opinions/_form.html.erb
+++ b/app/views/opinions/_form.html.erb
@@ -9,7 +9,7 @@
         </div>
       <% end %>
     <% else %>
-      <p><%= t('opinions.form.opinion_login_prompt') %></p>
+      <p class="text-center text-lg text-red-500 text-bold"><i class="fa-regular fa-circle-user mr-2"></i><%= t('opinions.form.opinion_login_prompt')%></p>
     <% end %>
   </div>
 </div>

--- a/app/views/questions/_question_content.erb
+++ b/app/views/questions/_question_content.erb
@@ -7,25 +7,28 @@
     </div>
 
     <div class="flex items-center space-x-3 mt-8 pt-4 border-t border-gray-200">
-    <img src="<%= question.user.google_image_url %>" alt="<%= question.user.name %>" class="w-10 h-10 rounded-full">
-    <span class="font-md"><%= t('.creater')%>: <%= @question.user.name %></span>
+      <img src="<%= question.user.google_image_url %>" alt="<%= question.user.name %>" class="w-10 h-10 rounded-full">
+      <span class="font-md"><%= t('.creater')%>: <%= @question.user.name %></span>
 
-    <div class="ml-auto flex items-center space-x-2">
-      <% if @question.editable? && @question.user == current_user %>
-          <%= link_to edit_question_path(question), data: { turbo_frame: "question_#{question.id}" }, class: "text-gray-500 hover:text-gray-900" do%>
-            <%= t('.edit') %><i class="fa-solid fa-pen-to-square"></i>
+      <div class="ml-auto flex items-center space-x-2">
+        <% if question.user == current_user %>
+          <% if @question.editable? %>
+              <%= link_to edit_question_path(question), data: { turbo_frame: "question_#{question.id}" }, class: "text-gray-500 hover:text-gray-900" do%>
+                <%= t('.edit') %><i class="fa-solid fa-pen-to-square"></i>
+              <% end %>
+              <%= button_to question_path(question), method: :delete, form: { data: { turbo_confirm: t('.delete_confirm'), turbo_frame: '_top'}}, class: "text-red-500 hover:text-red-700" do%>
+                <%= t('.destroy')%><i class="fa-solid fa-trash"></i>
+              <% end %>
+          
+          <% elsif @question.has_responses? %>
+              <p><%= t('.cannot_edit_due_to_replies')%></p>
+              <%= button_to question_path(question), method: :delete, form: { data: { turbo_confirm: t('.delete_confirm'), turbo_frame: '_top'}}, class: "text-red-500 hover:text-red-700" do%>
+                <%= t('.destroy')%><i class="fa-solid fa-trash"></i>
+              <% end %>
           <% end %>
-          <%= button_to question_path(question), method: :delete, form: { data: { turbo_confirm: t('.delete_confirm'), turbo_frame: '_top'}}, class: "text-red-500 hover:text-red-700" do%>
-            <%= t('.destroy')%><i class="fa-solid fa-trash"></i>
-          <% end %>
-      
-      <% elsif @question.has_responses? %>
-          <p><%= t('.cannot_edit_due_to_replies')%></p>
-          <%= button_to question_path(question), method: :delete, form: { data: { turbo_confirm: t('.delete_confirm'), turbo_frame: '_top'}}, class: "text-red-500 hover:text-red-700" do%>
-            <%= t('.destroy')%><i class="fa-solid fa-trash"></i>
-          <% end %>
-      <% end %>
-    </div>
+        <% else %>
+        <% end %>
+      </div>
     </div>
   </div>
 </div>

--- a/app/views/questions/_question_content.erb
+++ b/app/views/questions/_question_content.erb
@@ -1,25 +1,31 @@
 <h1 class="text-3xl font-extrabold mb-4"><%= question.title %></h1>
 
 <div class="mb-6">
-    <div class="space-y-4">
-        <div id="voting-section">
-            <%= render 'options_with_results', question: question, current_user: current_user %>
-        </div>
-
-        <div class="flex items-center space-x-3 mt-8 pt-4 border-t border-gray-200">
-        <img src="<%= question.user.google_image_url %>" alt="<%= question.user.name %>" class="w-10 h-10 rounded-full">
-        <span class="font-md"><%= t('.creater')%>: <%= @question.user.name %></span>
-
-        <% if current_user == question.user %>
-            <div class="ml-auto flex items-center space-x-2">
-                <%= link_to edit_question_path(question), data: { turbo_frame: "question_#{question.id}" }, class: "text-gray-500 hover:text-gray-900" do%>
-                  <%= t('.edit') %><i class="fa-solid fa-pen-to-square"></i>
-                <% end %>
-                <%= button_to question_path(question), method: :delete, form: { data: { turbo_confirm: t('.delete_confirm'), turbo_frame: '_top'}}, class: "text-red-500 hover:text-red-700" do%>
-                  <%= t('.destroy')%><i class="fa-solid fa-trash"></i>
-                <% end %>
-            </div>
-        <% end %>
-        </div>
+  <div class="space-y-4">
+    <div id="voting-section">
+      <%= render 'options_with_results', question: question, current_user: current_user %>
     </div>
+
+    <div class="flex items-center space-x-3 mt-8 pt-4 border-t border-gray-200">
+    <img src="<%= question.user.google_image_url %>" alt="<%= question.user.name %>" class="w-10 h-10 rounded-full">
+    <span class="font-md"><%= t('.creater')%>: <%= @question.user.name %></span>
+
+    <div class="ml-auto flex items-center space-x-2">
+      <% if @question.editable? && @question.user == current_user %>
+          <%= link_to edit_question_path(question), data: { turbo_frame: "question_#{question.id}" }, class: "text-gray-500 hover:text-gray-900" do%>
+            <%= t('.edit') %><i class="fa-solid fa-pen-to-square"></i>
+          <% end %>
+          <%= button_to question_path(question), method: :delete, form: { data: { turbo_confirm: t('.delete_confirm'), turbo_frame: '_top'}}, class: "text-red-500 hover:text-red-700" do%>
+            <%= t('.destroy')%><i class="fa-solid fa-trash"></i>
+          <% end %>
+      
+      <% elsif @question.has_responses? %>
+          <p class="text-muted">※ 既に回答・意見があるため、編集はできません</p>
+          <%= button_to question_path(question), method: :delete, form: { data: { turbo_confirm: t('.delete_confirm'), turbo_frame: '_top'}}, class: "text-red-500 hover:text-red-700" do%>
+            <%= t('.destroy')%><i class="fa-solid fa-trash"></i>
+          <% end %>
+      <% end %>
+    </div>
+    </div>
+  </div>
 </div>

--- a/app/views/questions/_question_content.erb
+++ b/app/views/questions/_question_content.erb
@@ -20,7 +20,7 @@
           <% end %>
       
       <% elsif @question.has_responses? %>
-          <p class="text-muted">※ 既に回答・意見があるため、編集はできません</p>
+          <p><%= t('.cannot_edit_due_to_replies')%></p>
           <%= button_to question_path(question), method: :delete, form: { data: { turbo_confirm: t('.delete_confirm'), turbo_frame: '_top'}}, class: "text-red-500 hover:text-red-700" do%>
             <%= t('.destroy')%><i class="fa-solid fa-trash"></i>
           <% end %>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -44,6 +44,7 @@ ja:
       edit: 編集
       destroy: 削除
       delete_confirm: "本当に削除しますか?"
+      cannot_edit_due_to_replies: "※ 既に回答・意見があるため、編集はできません"
     edit_form:
       creater: 作成者
       cancel: キャンセル

--- a/spec/system/questions_spec.rb
+++ b/spec/system/questions_spec.rb
@@ -215,8 +215,10 @@ RSpec.describe "Questions", type: :system do
     end
 
     describe 'GET /edit' do
-      let!(:question) { create(:question, :with_options, user: user) }
+      let!(:question) { create(:question, user: user) }
       let!(:other_user) { create(:user) }
+      let!(:option1) { create(:option, question: question) }
+      let!(:option2) { create(:option, question: question) }
 
       context '自分の投稿の場合' do
         before do
@@ -229,8 +231,8 @@ RSpec.describe "Questions", type: :system do
             expect(page).to have_button '更新'
             expect(page).to have_link 'キャンセル'
             expect(page).to have_field('タイトル', with: question.title)
-            expect(page).to have_field('選択肢1', with: question.options.first.content)
-            expect(page).to have_field('選択肢2', with: question.options.last.content)
+            expect(page).to have_field('選択肢1', with: option1.content)
+            expect(page).to have_field('選択肢2', with: option2.content)
         end
       end
 
@@ -243,6 +245,32 @@ RSpec.describe "Questions", type: :system do
             it '編集ボタンが表示されないこと' do
                 expect(page).not_to have_link '編集'
             end
+        end
+
+        context '既に投票がある場合' do
+          before do
+            vote = create(:vote, option: option1, user: other_user)
+            login(user)
+            visit question_path(question)
+          end
+
+          it '編集リンクが表示されず、編集不可メッセージが表示されること' do
+            expect(page).not_to have_link '編集'
+            expect(page).to have_content('※ 既に回答・意見があるため、編集はできません')
+          end
+        end
+
+        context '既に意見がある場合' do
+          before do
+            create(:opinion, question: question, user: other_user)
+            login(user)
+            visit question_path(question)
+          end
+
+          it '編集リンクが表示されず、編集不可メッセージが表示されること' do
+            expect(page).not_to have_link '編集'
+            expect(page).to have_content('※ 既に回答・意見があるため、編集はできません')
+          end
         end
     end
 


### PR DESCRIPTION
お題を編集する際に、
・すでに投票があるもの
・すでに意見（コメント）されているもの

に関しては、編集できないように制限しました。
テストコードも追加して、通過しております。