### PR TITLE
ソート機能実装＋意見のレイアウト修正

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -76,6 +76,7 @@
   @apply shadow-xl -translate-y-0.5;
 }
 
+/* それなボタン */
 .reaction-button {
   position: relative;
   display: inline-flex;
@@ -165,6 +166,7 @@
   background: #a0aec0;
 }
 
+/* セレクトボックス */
 .selectbox {
     position: relative;
     display: inline-block;
@@ -183,11 +185,10 @@
     width: 2.8em;
     height: 100%;
     border-radius: 0 3px 3px 0;
-    background-color: #ff6f00;
+    background-color: #55a0e6;
     content: '';
 }
 
-/* プルダウンの右側にある白い矢印部分 */
 .selectbox::after {
     position: absolute;
     top: 50%;
@@ -200,24 +201,23 @@
     content: '';
 }
 
-
 .selectbox select {
     appearance: none;
     -webkit-appearance: none;
     -moz-appearance: none;
     
-    /* 外観の調整 */
     min-width: 230px;
     height: 2.8em;
     padding: .4em 3.6em .4em .8em;
-    border: 2px solid #ff6f00;
+    border: 2px solid #55a0e6;
     border-radius: 3px;
+    color: #413e3e;
     font-size: 1em;
     cursor: pointer;
 }
 
 .selectbox select:focus {
-    outline: 1px solid #ff6f00;
+    outline: 0.5px solid #55a0e6;
 }
 
 /* Google Sign-In Button Component */

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -165,6 +165,61 @@
   background: #a0aec0;
 }
 
+.selectbox {
+    position: relative;
+    display: inline-block;
+}
+
+.selectbox::before,
+.selectbox::after {
+    position: absolute;
+    content: '';
+    pointer-events: none;
+}
+
+.selectbox::before {
+    right: 0;
+    top: 0;
+    width: 2.8em;
+    height: 100%;
+    border-radius: 0 3px 3px 0;
+    background-color: #ff6f00;
+    content: '';
+}
+
+/* プルダウンの右側にある白い矢印部分 */
+.selectbox::after {
+    position: absolute;
+    top: 50%;
+    right: 1.4em;
+    transform: translate(50%, -50%) rotate(45deg);
+    width: 6px;
+    height: 6px;
+    border-bottom: 3px solid #fff;
+    border-right: 3px solid #fff;
+    content: '';
+}
+
+
+.selectbox select {
+    appearance: none;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    
+    /* 外観の調整 */
+    min-width: 230px;
+    height: 2.8em;
+    padding: .4em 3.6em .4em .8em;
+    border: 2px solid #ff6f00;
+    border-radius: 3px;
+    font-size: 1em;
+    cursor: pointer;
+}
+
+.selectbox select:focus {
+    outline: 1px solid #ff6f00;
+}
+
 /* Google Sign-In Button Component */
 .gsi-material-button {
   @apply select-none appearance-none bg-white border border-gray-700 rounded-full box-border text-gray-800 cursor-pointer font-sans text-sm h-10 tracking-wider outline-none overflow-hidden px-3 relative text-center transition-all duration-200 ease-in-out align-middle whitespace-nowrap w-auto max-w-lg min-w-0;

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -5,15 +5,15 @@ class QuestionsController < ApplicationController
 
   def index
     @questions = case params[:sort_by]
-                 when 'most_voted'
-                   Question.most_voted
-                 when 'most_opinions'
-                   Question.most_opinions
-                 when 'oldest'
-                   Question.oldest
-                 else
-                   Question.order(created_at: :desc)
-                 end
+    when "most_voted"
+                   Question.most_voted.includes(:user)
+    when "most_opinions"
+                   Question.most_opinions.includes(:user)
+    when "oldest"
+                   Question.oldest.includes(:user)
+    else
+                   Question.order(created_at: :desc).includes(:user)
+    end
   end
 
   def show

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -4,7 +4,16 @@ class QuestionsController < ApplicationController
   before_action :check_user, only: %i[ edit update destroy ]
 
   def index
-    @questions = Question.all.includes(:user).order(created_at: :desc).page(params[:page]).per(12)
+    @questions = case params[:sort_by]
+                 when 'most_voted'
+                   Question.most_voted
+                 when 'most_opinions'
+                   Question.most_opinions
+                 when 'oldest'
+                   Question.oldest
+                 else
+                   Question.order(created_at: :desc)
+                 end
   end
 
   def show

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,7 +3,16 @@ class UsersController < ApplicationController
   before_action :correct_user, only: %i[ show edit update]
 
 def show
-  @questions = @user.questions.includes(:user).order(created_at: :desc)
+  @questions = case params[:sort_by]
+               when 'most_voted'
+                 @user.questions.most_voted
+               when 'most_opinions'
+                 @user.questions.most_opinions
+               when 'oldest'
+                 @user.questions.oldest
+               else
+                 @user.questions.order(created_at: :desc)
+               end
 end
 
   def edit

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,15 +4,15 @@ class UsersController < ApplicationController
 
 def show
   @questions = case params[:sort_by]
-               when 'most_voted'
-                 @user.questions.most_voted
-               when 'most_opinions'
-                 @user.questions.most_opinions
-               when 'oldest'
-                 @user.questions.oldest
-               else
-                 @user.questions.order(created_at: :desc)
-               end
+  when "most_voted"
+                 @user.questions.most_voted.includes(:user)
+  when "most_opinions"
+                 @user.questions.most_opinions.includes(:user)
+  when "oldest"
+                 @user.questions.oldest.includes(:user)
+  else
+                 @user.questions.order(created_at: :desc).includes(:user)
+  end
 end
 
   def edit

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -8,6 +8,16 @@ class Question < ApplicationRecord
   validates :title, presence: true, length: { maximum: 29 }
   validates :user_id, presence: true
 
+  scope :most_voted, -> {
+    left_joins(:votes).group('questions.id').order('COUNT(votes.id) DESC')
+  }
+
+  scope :most_opinions, -> {
+    left_joins(:opinions.)group('questions.id').order('COUNT(opinions.id)DESC')
+  }
+
+  scope :oldest, -> { order(created_at: :asc) }
+
   def total_votes
     votes.count
   end
@@ -19,4 +29,5 @@ class Question < ApplicationRecord
   def has_responses?
     votes.exists? || opinions.exists?
   end
+
 end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -13,7 +13,7 @@ class Question < ApplicationRecord
   }
 
   scope :most_opinions, -> {
-    left_joins(:opinions.)group('questions.id').order('COUNT(opinions.id)DESC')
+    left_joins(:opinions).group('questions.id').order('COUNT(opinions.id) DESC')
   }
 
   scope :oldest, -> { order(created_at: :asc) }

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -9,11 +9,11 @@ class Question < ApplicationRecord
   validates :user_id, presence: true
 
   scope :most_voted, -> {
-    left_joins(:votes).group('questions.id').order('COUNT(votes.id) DESC')
+    left_joins(:votes).group("questions.id").order("COUNT(votes.id) DESC")
   }
 
   scope :most_opinions, -> {
-    left_joins(:opinions).group('questions.id').order('COUNT(opinions.id) DESC')
+    left_joins(:opinions).group("questions.id").order("COUNT(opinions.id) DESC")
   }
 
   scope :oldest, -> { order(created_at: :asc) }
@@ -29,5 +29,4 @@ class Question < ApplicationRecord
   def has_responses?
     votes.exists? || opinions.exists?
   end
-
 end

--- a/app/views/opinions/_opinion.html.erb
+++ b/app/views/opinions/_opinion.html.erb
@@ -1,6 +1,10 @@
 <%= turbo_frame_tag "opinion_#{opinion.id}", class: "block mb-6 pb-4 border-b border-gray-200" do %>
   <div class="flex items-center mb-2">
-    <img src="<%= opinion.user.google_image_url %>" alt="<%= opinion.user.name %>" class="w-6 h-6 rounded-full">
+    <% if opinion.user.avatar.attached? %>
+      <%= image_tag opinion.user.avatar_thumbnail, alt: opinion.user.name, class: "w-6 h-6 rounded-full" %>
+    <% else %>
+      <img src="<%= opinion.user.google_image_url %>" alt="<%= opinion.user.name %>" class="w-6 h-6 rounded-full">
+    <% end %>
     <div class="ml-2 font-semibold text-gray-800">
       <%= opinion.user.name %>
     </div>

--- a/app/views/questions/_question.html.erb
+++ b/app/views/questions/_question.html.erb
@@ -1,4 +1,4 @@
-<%= link_to question_path(question), data: { turbo_frame: "_top" }, class: "block no-underline" do %>
+<%= link_to question_path(question), class: "block no-underline" do %>
   <div class="bg-white border border-orange shadow-md w-80 h-50 p-6 mt-6 rounded-lg card-animated space-y-4">
     <h2 class="text-xl font-bold"><%= question.title %></h2>
     <div class="flex items-center space-x-2">

--- a/app/views/questions/index.html.erb
+++ b/app/views/questions/index.html.erb
@@ -2,24 +2,21 @@
 <div class="h-full">
   <div class="container mx-auto p-4">
     <div class="questions-container">
-      <%= turbo_frame_tag "questions-page-#{@questions.current_page}" do %>
-        <div class="mb-8">
-          <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4 gap-4 lg:gap-5 2xl:gap-6 justify-items-center">
-            <%= render @questions %>
-          </div>
-        </div>
-
-        <% if @questions.next_page %>
-          <%= turbo_frame_tag "questions-page-#{@questions.next_page}",
-              loading: :lazy,
-              src: questions_path(page: @questions.next_page) do %>
-            <div class="mb-8">
-              <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4 gap-4 lg:gap-5 2xl:gap-6 justify-items-center">
-              </div>
-            </div>
-          <% end %>
-        <% end %>
+      <%= form_with url: questions_path, method: :get, local: true do %>
+        <%= select_tag :sort_by, options_for_select([
+          ['新着順', 'latest'],
+          ['古い順', 'oldest'],
+          ['投票数が多い順', 'most_voted'],
+          ['意見数が多い順', 'most_opinions']
+        ], params[:sort_by]),
+        class: "",
+        onchange: 'this.form.submit();' %>
       <% end %>
+      <div class="mb-8">
+        <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4 gap-4 lg:gap-5 2xl:gap-6 justify-items-center">
+          <%= render @questions %>
+        </div>
+      </div>
     </div>
   </div>
 </div>

--- a/app/views/questions/index.html.erb
+++ b/app/views/questions/index.html.erb
@@ -3,14 +3,16 @@
   <div class="container mx-auto p-4">
     <div class="questions-container">
       <%= form_with url: questions_path, method: :get, local: true do %>
-        <%= select_tag :sort_by, options_for_select([
-          ['新着順', 'latest'],
-          ['古い順', 'oldest'],
-          ['投票数が多い順', 'most_voted'],
-          ['意見数が多い順', 'most_opinions']
-        ], params[:sort_by]),
-        class: "",
-        onchange: 'this.form.submit();' %>
+        <div class= "selectbox mb-4">
+          <%= select_tag :sort_by, options_for_select([
+            ['新着順', 'latest'],
+            ['古い順', 'oldest'],
+            ['投票数が多い順', 'most_voted'],
+            ['意見数が多い順', 'most_opinions']
+          ], params[:sort_by]),
+          class: "selectbox-select",
+          onchange: 'this.form.submit();' %>
+        </div>
       <% end %>
       <div class="mb-8">
         <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4 gap-4 lg:gap-5 2xl:gap-6 justify-items-center">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -9,6 +9,18 @@
   <h2 class="mt-15 text-2xl text-center"><%= t('.your_questions')%></h2>
   <% if @questions.any? %>
     <div class="mt-8">
+      <%= form_with url: user_path, method: :get, local: true do %>
+        <div class= "selectbox mb-4">
+          <%= select_tag :sort_by, options_for_select([
+            ['新着順', 'latest'],
+            ['古い順', 'oldest'],
+            ['投票数が多い順', 'most_voted'],
+            ['意見数が多い順', 'most_opinions']
+          ], params[:sort_by]),
+          class: "selectbox-select",
+          onchange: 'this.form.submit();' %>
+        </div>
+      <% end %>
       <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4 gap-4 lg:gap-5 2xl:gap-6 justify-items-center">
         <% @questions.each do |question| %>
           <%= render "questions/question", question: question %>


### PR DESCRIPTION
お題一覧画面とマイページにて以下の並べ替えができるようになりました。
新着順・古い順・投票数が多い順・意見数が多い順


また意見を投稿した際に、ユーザーが設定したアイコンが反映されていなかった為
修正しました。